### PR TITLE
Allow useNativeDriver to be passed to RewardComponent

### DIFF
--- a/RewardsComponent.js
+++ b/RewardsComponent.js
@@ -104,9 +104,13 @@ class RewardsComponent extends Component {
         <View style={{ alignItems: 'center', justifyContent: 'center' }}>
           {items}
         </View>
-        <SpringAnim pose={state}>
+        {this.props.shake
+        ? <SpringAnim pose={state}>
           {children}
         </SpringAnim>
+        : <View>
+          {children}
+        </View>}
       </View>
     );
   }
@@ -125,6 +129,7 @@ RewardsComponent.propTypes = {
   state: PropTypes.oneOf(['rest', 'reward', 'punish']),
   onRest: PropTypes.func,
   useNativeDriver: PropTypes.bool,
+  shake: PropTypes.bool,
 };
 
 RewardsComponent.defaultProps = {
@@ -150,5 +155,6 @@ RewardsComponent.defaultProps = {
   state: 'rest',
   onRest: () => {},
   useNativeDriver: true,
+  shake: true,
 };
 export default RewardsComponent;

--- a/RewardsComponent.js
+++ b/RewardsComponent.js
@@ -45,8 +45,8 @@ class RewardsComponent extends Component {
   }
 
   get animationParams() {
-    const { initialSpeed, spread, deacceleration, rotationXSpeed, rotationZSpeed } = this.props;
-    const params = { initialSpeed, spread, deacceleration, rotationXSpeed, rotationZSpeed };
+    const { initialSpeed, spread, deacceleration, rotationXSpeed, rotationZSpeed, useNativeDriver } = this.props;
+    const params = { initialSpeed, spread, deacceleration, rotationXSpeed, rotationZSpeed, useNativeDriver };
     return params;
   }
 
@@ -124,6 +124,7 @@ RewardsComponent.propTypes = {
   animationType: PropTypes.oneOf(['confetti', 'emoji']),
   state: PropTypes.oneOf(['rest', 'reward', 'punish']),
   onRest: PropTypes.func,
+  useNativeDriver: PropTypes.bool,
 };
 
 RewardsComponent.defaultProps = {
@@ -148,5 +149,6 @@ RewardsComponent.defaultProps = {
   animationType: 'confetti',
   state: 'rest',
   onRest: () => {},
+  useNativeDriver: true,
 };
 export default RewardsComponent;

--- a/confetti.js
+++ b/confetti.js
@@ -82,7 +82,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     // coast to a stop
     velocity: { x: xSpeed, y: ySpeed }, // velocity from gesture release
     deceleration: 0.989 + (1 - deacceleration) / 100,
-    useNativeDriver: useNativeDriver,
+    useNativeDriver,
   });
 
   const duration = 2000 + Math.random() * 100;
@@ -91,7 +91,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: 100 + Math.random() * 100, // Animate to opacity: 1 (opaque)
       duration, // Make it take a while
-      useNativeDriver: useNativeDriver,
+      useNativeDriver,
     },
   );
   const disapearAnimation = Animated.timing( // Animate over time
@@ -99,7 +99,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: 0, // Animate to opacity: 1 (opaque)
       duration, // Make it take a while
-      useNativeDriver: useNativeDriver,
+      useNativeDriver,
     },
   );
   const rotateXAnimation = Animated.timing(
@@ -107,7 +107,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: (Math.random() * 3) * rotationXSpeed,
       duration,
-      useNativeDriver: useNativeDriver,
+      useNativeDriver,
     },
   );
   const rotateZAnimation = Animated.timing(
@@ -115,7 +115,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: (Math.random() * 5) * rotationZSpeed,
       duration,
-      useNativeDriver: useNativeDriver,
+      useNativeDriver,
     },
   );
 

--- a/confetti.js
+++ b/confetti.js
@@ -68,7 +68,7 @@ export function generateConfettiAnimations(translations, params) {
 }
 
 function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, index, count, params) {
-  const { initialSpeed, spread, deacceleration, rotationXSpeed, rotationZSpeed } = params;
+  const { initialSpeed, spread, deacceleration, rotationXSpeed, rotationZSpeed, useNativeDriver } = params;
   const degrees = 0;
   const angle = degrees * Math.PI / 180;
   const vx = Math.cos(angle);
@@ -82,6 +82,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     // coast to a stop
     velocity: { x: xSpeed, y: ySpeed }, // velocity from gesture release
     deceleration: 0.989 + (1 - deacceleration) / 100,
+    useNativeDriver: useNativeDriver,
   });
 
   const duration = 2000 + Math.random() * 100;
@@ -90,6 +91,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: 100 + Math.random() * 100, // Animate to opacity: 1 (opaque)
       duration, // Make it take a while
+      useNativeDriver: useNativeDriver,
     },
   );
   const disapearAnimation = Animated.timing( // Animate over time
@@ -97,6 +99,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: 0, // Animate to opacity: 1 (opaque)
       duration, // Make it take a while
+      useNativeDriver: useNativeDriver,
     },
   );
   const rotateXAnimation = Animated.timing(
@@ -104,6 +107,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: (Math.random() * 3) * rotationXSpeed,
       duration,
+      useNativeDriver: useNativeDriver,
     },
   );
   const rotateZAnimation = Animated.timing(
@@ -111,6 +115,7 @@ function generateConfettiAnimation({ transform, opacity, rotateX, rotateZ }, ind
     {
       toValue: (Math.random() * 5) * rotationZSpeed,
       duration,
+      useNativeDriver: useNativeDriver,
     },
   );
 


### PR DESCRIPTION
React Native now requires useNativeDriver to be passed to Animated components (see [changelog](https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#deprecated-2)). It currently issues a warning when this is missing, which breaks my app on Expo.

The change allows passing this property to the component. It defaults to  true.